### PR TITLE
Feature: Bulk Music Disc Assignment

### DIFF
--- a/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
@@ -209,6 +209,7 @@ public class AudioPlayerCommands {
         literalBuilder.then(applyCommand(Commands.literal("musicdisc"), itemStack -> itemStack.getItem() instanceof RecordItem, "Music Disc"));
         literalBuilder.then(applyCommand(Commands.literal("goathorn"), itemStack -> itemStack.getItem() instanceof InstrumentItem, "Goat Horn"));
         literalBuilder.then(bulkApplyCommand(Commands.literal("musicdisc_bulk"), itemStack -> itemStack.getItem() instanceof BlockItem blockitem && blockitem.getBlock() instanceof ShulkerBoxBlock, "Shulker Box"));
+        literalBuilder.then(bulkApplyCommand(Commands.literal("goathorn_bulk"), itemStack -> itemStack.getItem() instanceof BlockItem blockitem && blockitem.getBlock() instanceof ShulkerBoxBlock, "Shulker Box"));
 
         literalBuilder.then(Commands.literal("clear")
                 .executes((context) -> {
@@ -386,7 +387,7 @@ public class AudioPlayerCommands {
                             UUID sound = UuidArgument.getUuid(context, "sound");
                             ItemStack itemInHand = player.getItemInHand(InteractionHand.MAIN_HAND);
                             if (validator.test(itemInHand)) {
-                                processShulker(context, itemInHand, sound, null);
+                                processShulker(context, itemInHand, itemTypeName, sound, null);
                             } else {
                                 context.getSource().sendFailure(Component.literal("You don't have a %s in your main hand".formatted(itemTypeName)));
                             }
@@ -399,7 +400,7 @@ public class AudioPlayerCommands {
                                     ItemStack itemInHand = player.getItemInHand(InteractionHand.MAIN_HAND);
                                     String customName = StringArgumentType.getString(context, "custom_name");
                                     if (validator.test(itemInHand)) {
-                                        processShulker(context, itemInHand, sound, customName);
+                                        processShulker(context, itemInHand, itemTypeName, sound, customName);
                                     } else {
                                         context.getSource().sendFailure(Component.literal("You don't have a %s in your main hand".formatted(itemTypeName)));
                                     }
@@ -407,7 +408,7 @@ public class AudioPlayerCommands {
                                 })));
     }
 
-    private static void processShulker(CommandContext<CommandSourceStack> context, ItemStack itemInHand, UUID soundID, @Nullable String name) {
+    private static void processShulker(CommandContext<CommandSourceStack> context, ItemStack itemInHand, String itemTypeName, UUID soundID, @Nullable String name) {
         ListTag shulkerContents = itemInHand.getTagElement("BlockEntityTag").getList("Items", 10);
         for (int i = 0; i < shulkerContents.size(); i++) {
             CompoundTag currentItem = shulkerContents.getCompound(i);
@@ -418,7 +419,7 @@ public class AudioPlayerCommands {
             }
         }
         itemInHand.getTagElement("BlockEntityTag").put("Items", shulkerContents);
-        context.getSource().sendSuccess(Component.literal("Successfully updated %s contents".formatted(itemInHand.getHoverName())), false);
+        context.getSource().sendSuccess(Component.literal("Successfully updated %s contents".formatted(itemTypeName)), false);
     }
 
     private static void renameItem(CommandContext<CommandSourceStack> context, ItemStack stack, UUID soundID, @Nullable String name) {

--- a/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
@@ -386,21 +386,15 @@ public class AudioPlayerCommands {
                             UUID sound = UuidArgument.getUuid(context, "sound");
                             ItemStack itemInHand = player.getItemInHand(InteractionHand.MAIN_HAND);
                             if (validator.test(itemInHand)) {
-                                // Gather a list of the items in the shulker box
                                 ListTag shulkerContents = itemInHand.getTagElement("BlockEntityTag").getList("Items",10);
-                                // Iterate through the list of items
                                 for (int i = 0; i < shulkerContents.size(); i++) {
-                                    // All data on current item
                                     CompoundTag currentItem = shulkerContents.getCompound(i);
-                                    // Make a copy with type converted from Tag to ItemStack
                                     ItemStack itemStack = ItemStack.of(currentItem);
-                                    // Check if the item is a music disc. If so, perform custom tagging and overwrite tag in original list
                                     if (itemStack.getItem() instanceof RecordItem) {
                                         renameItem(context, itemStack, sound, null);
                                         shulkerContents.getCompound(i).put("tag", itemStack.getTag());
                                     }
                                 }
-                                // Overwrite shulker box item data with the updated list
                                 itemInHand.getTagElement("BlockEntityTag").put("Items", shulkerContents);
                                 context.getSource().sendSuccess(Component.literal("Successfully updated Shulker Box contents"), false);
                             } else {

--- a/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
@@ -26,6 +26,7 @@ import net.minecraft.world.item.InstrumentItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.RecordItem;
 import net.minecraft.world.level.block.ShulkerBoxBlock;
+import net.minecraft.world.level.block.entity.ShulkerBoxBlockEntity;
 import org.jetbrains.annotations.Nullable;
 
 import javax.sound.sampled.UnsupportedAudioFileException;
@@ -409,7 +410,7 @@ public class AudioPlayerCommands {
     }
 
     private static void processShulker(CommandContext<CommandSourceStack> context, ItemStack itemInHand, String actionItem, String itemTypeName, UUID soundID, @Nullable String name) {
-        ListTag shulkerContents = itemInHand.getTagElement(BlockItem.BLOCK_ENTITY_TAG).getList("Items", 10);
+        ListTag shulkerContents = itemInHand.getTagElement(BlockItem.BLOCK_ENTITY_TAG).getList(ShulkerBoxBlockEntity.ITEMS_TAG, 10);
         for (int i = 0; i < shulkerContents.size(); i++) {
             CompoundTag currentItem = shulkerContents.getCompound(i);
             ItemStack itemStack = ItemStack.of(currentItem);

--- a/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
@@ -386,17 +386,7 @@ public class AudioPlayerCommands {
                             UUID sound = UuidArgument.getUuid(context, "sound");
                             ItemStack itemInHand = player.getItemInHand(InteractionHand.MAIN_HAND);
                             if (validator.test(itemInHand)) {
-                                ListTag shulkerContents = itemInHand.getTagElement("BlockEntityTag").getList("Items",10);
-                                for (int i = 0; i < shulkerContents.size(); i++) {
-                                    CompoundTag currentItem = shulkerContents.getCompound(i);
-                                    ItemStack itemStack = ItemStack.of(currentItem);
-                                    if (itemStack.getItem() instanceof RecordItem) {
-                                        renameItem(context, itemStack, sound, null);
-                                        shulkerContents.getCompound(i).put("tag", itemStack.getTag());
-                                    }
-                                }
-                                itemInHand.getTagElement("BlockEntityTag").put("Items", shulkerContents);
-                                context.getSource().sendSuccess(Component.literal("Successfully updated %s contents".formatted(itemTypeName)), false);
+                                processShulker(context, itemInHand, sound, null);
                             } else {
                                 context.getSource().sendFailure(Component.literal("You don't have a %s in your main hand".formatted(itemTypeName)));
                             }
@@ -409,22 +399,26 @@ public class AudioPlayerCommands {
                                     ItemStack itemInHand = player.getItemInHand(InteractionHand.MAIN_HAND);
                                     String customName = StringArgumentType.getString(context, "custom_name");
                                     if (validator.test(itemInHand)) {
-                                        ListTag shulkerContents = itemInHand.getTagElement("BlockEntityTag").getList("Items",10);
-                                        for (int i = 0; i < shulkerContents.size(); i++) {
-                                            CompoundTag currentItem = shulkerContents.getCompound(i);
-                                            ItemStack itemStack = ItemStack.of(currentItem);
-                                            if (itemStack.getItem() instanceof RecordItem) {
-                                                renameItem(context, itemStack, sound, customName);
-                                                shulkerContents.getCompound(i).put("tag", itemStack.getTag());
-                                            }
-                                        }
-                                        itemInHand.getTagElement("BlockEntityTag").put("Items", shulkerContents);
-                                        context.getSource().sendSuccess(Component.literal("Successfully updated %s contents".formatted(itemTypeName)), false);
+                                        processShulker(context, itemInHand, sound, customName);
                                     } else {
                                         context.getSource().sendFailure(Component.literal("You don't have a %s in your main hand".formatted(itemTypeName)));
                                     }
                                     return 1;
                                 })));
+    }
+
+    private static void processShulker(CommandContext<CommandSourceStack> context, ItemStack itemInHand, UUID soundID, @Nullable String name) {
+        ListTag shulkerContents = itemInHand.getTagElement("BlockEntityTag").getList("Items", 10);
+        for (int i = 0; i < shulkerContents.size(); i++) {
+            CompoundTag currentItem = shulkerContents.getCompound(i);
+            ItemStack itemStack = ItemStack.of(currentItem);
+            if (itemStack.getItem() instanceof RecordItem) {
+                renameItem(context, itemStack, soundID, name);
+                shulkerContents.getCompound(i).put("tag", itemStack.getTag());
+            }
+        }
+        itemInHand.getTagElement("BlockEntityTag").put("Items", shulkerContents);
+        context.getSource().sendSuccess(Component.literal("Successfully updated %s contents".formatted(itemInHand.getHoverName())), false);
     }
 
     private static void renameItem(CommandContext<CommandSourceStack> context, ItemStack stack, UUID soundID, @Nullable String name) {

--- a/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
@@ -409,7 +409,7 @@ public class AudioPlayerCommands {
     }
 
     private static void processShulker(CommandContext<CommandSourceStack> context, ItemStack itemInHand, String actionItem, String itemTypeName, UUID soundID, @Nullable String name) {
-        ListTag shulkerContents = itemInHand.getTagElement("BlockEntityTag").getList("Items", 10);
+        ListTag shulkerContents = itemInHand.getTagElement(BlockItem.BLOCK_ENTITY_TAG).getList("Items", 10);
         for (int i = 0; i < shulkerContents.size(); i++) {
             CompoundTag currentItem = shulkerContents.getCompound(i);
             ItemStack itemStack = ItemStack.of(currentItem);
@@ -418,7 +418,7 @@ public class AudioPlayerCommands {
                 shulkerContents.getCompound(i).put("tag", itemStack.getTag());
             }
         }
-        itemInHand.getTagElement("BlockEntityTag").put("Items", shulkerContents);
+        itemInHand.getTagElement(BlockItem.BLOCK_ENTITY_TAG).put("Items", shulkerContents);
         context.getSource().sendSuccess(Component.literal("Successfully updated %s contents".formatted(itemTypeName)), false);
     }
 

--- a/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
@@ -33,6 +33,7 @@ import javax.sound.sampled.UnsupportedAudioFileException;
 import java.net.UnknownHostException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -410,7 +411,7 @@ public class AudioPlayerCommands {
     }
 
     private static void processShulker(CommandContext<CommandSourceStack> context, ItemStack itemInHand, String actionItem, String itemTypeName, UUID soundID, @Nullable String name) {
-        ListTag shulkerContents = itemInHand.getTagElement(BlockItem.BLOCK_ENTITY_TAG).getList(ShulkerBoxBlockEntity.ITEMS_TAG, 10);
+        ListTag shulkerContents = Objects.requireNonNull(itemInHand.getTagElement(BlockItem.BLOCK_ENTITY_TAG)).getList(ShulkerBoxBlockEntity.ITEMS_TAG, Tag.TAG_COMPOUND);
         for (int i = 0; i < shulkerContents.size(); i++) {
             CompoundTag currentItem = shulkerContents.getCompound(i);
             ItemStack itemStack = ItemStack.of(currentItem);
@@ -419,7 +420,7 @@ public class AudioPlayerCommands {
                 shulkerContents.getCompound(i).put("tag", itemStack.getTag());
             }
         }
-        itemInHand.getTagElement(BlockItem.BLOCK_ENTITY_TAG).put("Items", shulkerContents);
+        Objects.requireNonNull(itemInHand.getTagElement(BlockItem.BLOCK_ENTITY_TAG)).put("Items", shulkerContents);
         context.getSource().sendSuccess(Component.literal("Successfully updated %s contents".formatted(itemTypeName)), false);
     }
 

--- a/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
@@ -417,7 +417,7 @@ public class AudioPlayerCommands {
             ItemStack itemStack = ItemStack.of(currentItem);
             if (itemValidator.test(itemStack)) {
                 renameItem(context, itemStack, soundID, name);
-                shulkerContents.getCompound(i).put("tag", itemStack.getOrCreateTag());
+                currentItem.put("tag", itemStack.getOrCreateTag());
             }
         }
         itemInHand.getOrCreateTagElement(BlockItem.BLOCK_ENTITY_TAG).put(ShulkerBoxBlockEntity.ITEMS_TAG, shulkerContents);

--- a/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
@@ -208,7 +208,7 @@ public class AudioPlayerCommands {
 
         literalBuilder.then(applyCommand(Commands.literal("musicdisc"), itemStack -> itemStack.getItem() instanceof RecordItem, "Music Disc"));
         literalBuilder.then(applyCommand(Commands.literal("goathorn"), itemStack -> itemStack.getItem() instanceof InstrumentItem, "Goat Horn"));
-        literalBuilder.then(bulkApplyCommand(Commands.literal("musicdisc_bulk"), itemStack -> itemStack.getItem() instanceof BlockItem blockitem && blockitem.getBlock() instanceof ShulkerBoxBlock));
+        literalBuilder.then(bulkApplyCommand(Commands.literal("musicdisc_bulk"), itemStack -> itemStack.getItem() instanceof BlockItem blockitem && blockitem.getBlock() instanceof ShulkerBoxBlock, "Shulker Box"));
 
         literalBuilder.then(Commands.literal("clear")
                 .executes((context) -> {
@@ -378,7 +378,7 @@ public class AudioPlayerCommands {
                                 })));
     }
 
-    private static LiteralArgumentBuilder<CommandSourceStack> bulkApplyCommand(LiteralArgumentBuilder<CommandSourceStack> builder, Predicate<ItemStack> validator) {
+    private static LiteralArgumentBuilder<CommandSourceStack> bulkApplyCommand(LiteralArgumentBuilder<CommandSourceStack> builder, Predicate<ItemStack> validator, String itemTypeName) {
         return builder.requires((commandSource) -> commandSource.hasPermission(AudioPlayer.SERVER_CONFIG.applyToItemPermissionLevel.get()))
                 .then(Commands.argument("sound", UuidArgument.uuid())
                         .executes((context) -> {
@@ -396,9 +396,9 @@ public class AudioPlayerCommands {
                                     }
                                 }
                                 itemInHand.getTagElement("BlockEntityTag").put("Items", shulkerContents);
-                                context.getSource().sendSuccess(Component.literal("Successfully updated Shulker Box contents"), false);
+                                context.getSource().sendSuccess(Component.literal("Successfully updated %s contents".formatted(itemTypeName)), false);
                             } else {
-                                context.getSource().sendFailure(Component.literal("You don't have a Shulker Box in your main hand"));
+                                context.getSource().sendFailure(Component.literal("You don't have a %s in your main hand".formatted(itemTypeName)));
                             }
                             return 1;
                         })
@@ -419,9 +419,9 @@ public class AudioPlayerCommands {
                                             }
                                         }
                                         itemInHand.getTagElement("BlockEntityTag").put("Items", shulkerContents);
-                                        context.getSource().sendSuccess(Component.literal("Successfully updated Shulker Box contents"), false);
+                                        context.getSource().sendSuccess(Component.literal("Successfully updated %s contents".formatted(itemTypeName)), false);
                                     } else {
-                                        context.getSource().sendFailure(Component.literal("You don't have a Shulker Box in your main hand"));
+                                        context.getSource().sendFailure(Component.literal("You don't have a %s in your main hand".formatted(itemTypeName)));
                                     }
                                     return 1;
                                 })));

--- a/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
@@ -411,16 +411,16 @@ public class AudioPlayerCommands {
     }
 
     private static void processShulker(CommandContext<CommandSourceStack> context, ItemStack itemInHand, Predicate<ItemStack> itemValidator, String itemTypeName, UUID soundID, @Nullable String name) {
-        ListTag shulkerContents = Objects.requireNonNull(itemInHand.getTagElement(BlockItem.BLOCK_ENTITY_TAG)).getList(ShulkerBoxBlockEntity.ITEMS_TAG, Tag.TAG_COMPOUND);
+        ListTag shulkerContents = itemInHand.getOrCreateTagElement(BlockItem.BLOCK_ENTITY_TAG).getList(ShulkerBoxBlockEntity.ITEMS_TAG, Tag.TAG_COMPOUND);
         for (int i = 0; i < shulkerContents.size(); i++) {
             CompoundTag currentItem = shulkerContents.getCompound(i);
             ItemStack itemStack = ItemStack.of(currentItem);
             if (itemValidator.test(itemStack)) {
                 renameItem(context, itemStack, soundID, name);
-                shulkerContents.getCompound(i).put("tag", itemStack.getTag());
+                shulkerContents.getCompound(i).put("tag", itemStack.getOrCreateTag());
             }
         }
-        Objects.requireNonNull(itemInHand.getTagElement(BlockItem.BLOCK_ENTITY_TAG)).put(ShulkerBoxBlockEntity.ITEMS_TAG, shulkerContents);
+        itemInHand.getOrCreateTagElement(BlockItem.BLOCK_ENTITY_TAG).put(ShulkerBoxBlockEntity.ITEMS_TAG, shulkerContents);
         context.getSource().sendSuccess(Component.literal("Successfully updated %s contents".formatted(itemTypeName)), false);
     }
 

--- a/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
@@ -387,19 +387,32 @@ public class AudioPlayerCommands {
                             ItemStack itemInHand = player.getItemInHand(InteractionHand.MAIN_HAND);
                             if (validator.test(itemInHand)) {
                                 // Gather a list of the items in the shulker box
-                                ListTag shulkerContents = itemInHand.getTag().getCompound("BlockEntityTag").getList("Items", 10);
+                                ListTag shulkerContents = itemInHand.getTagElement("BlockEntityTag").getList("Items",10);
 
                                 // Iterate through the list of items
                                 for (int i = 0; i < shulkerContents.size(); i++) {
-                                    // Grab item from the list and convert from CompoundTag to ItemStack
-                                    ItemStack selectedItem = ItemStack.of(shulkerContents.getCompound(i));
+                                    // All data on current item
+                                    CompoundTag currentItem = shulkerContents.getCompound(i);
+
+                                    // Make a copy with type converted from Tag to ItemStack
+                                    ItemStack itemStack = ItemStack.of(currentItem);
+
                                     // Check if the item is a music disc and apply the custom data, otherwise move on
-                                    if (selectedItem.getItem() instanceof RecordItem) {
-                                        renameItem(context, selectedItem, sound, null);
+                                    if (itemStack.getItem() instanceof RecordItem) {
+                                        renameItem(context, itemStack, sound, null);
+                                    }
+
+                                    // Once processed, save any tag data back to the original list
+                                    if (itemStack.hasTag()) {
+                                        shulkerContents.getCompound(i).put("tag", itemStack.getTag());
                                     }
                                 }
 
-                                // Stuck. At this point we would need to translate back into an acceptable format to write the data back into the Shulker Box object.
+                                // Overwrite shulker box item data with the updated list
+                                itemInHand.getTagElement("BlockEntityTag").put("Items", shulkerContents);
+
+                                System.out.println("Printing shulker Items");
+                                System.out.println(itemInHand.getTag());
 
                             } else {
                                 context.getSource().sendFailure(Component.literal("You don't have a %s in your main hand".formatted(itemTypeName)));


### PR DESCRIPTION
Implementation for assigning a single custom sound (and name) to multiple music discs with a single command. See feature request #34 for further details on the original idea.

New Command: `/audioplayer musicdisc_bulk <ID> "<CUSTOM-TEXT>"`

- Checks for a shulker box in the player's hand
- Loops through all items checking for music discs and applying the custom tags
- Non-music disc items pass through unchanged