### PR TITLE
Added Stop Command

### DIFF
--- a/src/main/java/de/maxhenkel/audioplayer/PlayerManager.java
+++ b/src/main/java/de/maxhenkel/audioplayer/PlayerManager.java
@@ -66,7 +66,7 @@ public class PlayerManager {
                     audioPlayer.stopPlaying();
                 }
             }
-        }, player));
+        }, player, sound));
 
         executor.execute(() -> {
             de.maxhenkel.voicechat.api.audiochannel.AudioPlayer audioPlayer = playChannel(api, channel, level, sound, p, maxLengthSeconds);
@@ -148,7 +148,16 @@ public class PlayerManager {
     }
 
     private record PlayerReference(Stoppable onStop,
-                                   AtomicReference<de.maxhenkel.voicechat.api.audiochannel.AudioPlayer> player) {
+                                   AtomicReference<de.maxhenkel.voicechat.api.audiochannel.AudioPlayer> player, UUID sound) {
     }
 
+    @Nullable
+public UUID findChannelID(UUID sound) {
+    for (Map.Entry<UUID, PlayerReference> entry : players.entrySet()) {
+        if (entry.getValue().sound.equals(sound)) {
+            return entry.getKey();
+        }
+    }
+    return null;
+}
 }

--- a/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/AudioPlayerCommands.java
@@ -300,9 +300,33 @@ public class AudioPlayerCommands {
                                                     FloatArgumentType.getFloat(context, "range")
                                             );
                                         })))));
+        
+       literalBuilder.then(Commands.literal("stop")
+                        .requires((commandSource) -> commandSource.hasPermission(AudioPlayer.SERVER_CONFIG.playCommandPermissionLevel.get()))
+                        .then(Commands.argument("sound", UuidArgument.uuid())
+                                .executes(context -> stop(context, UuidArgument.getUuid(context, "sound")))
+    )
+);
 
         dispatcher.register(literalBuilder);
     }
+
+        private static int stop(CommandContext<CommandSourceStack> context, UUID sound) {
+                UUID channelID = PlayerManager.instance().findChannelID(sound);
+            
+                if (channelID != null) {
+                    PlayerManager.instance().stop(channelID);
+                                context.getSource()
+                                                .sendSuccess(() -> Component.literal(
+                                                                "Successfully stopped %s.".formatted(sound)),
+                                                                false);
+                                return 1;
+                        } else {
+                                context.getSource().sendFailure(Component
+                                                .literal("Failed to stop, Could not find %s".formatted(sound)));
+                        }
+                        return 0;
+            }
 
     private static int play(CommandContext<CommandSourceStack> context, UUID sound, Vec3 location, float range) {
         @Nullable ServerPlayer player = context.getSource().getPlayer();


### PR DESCRIPTION
### Decided to contribute to add my own request #56 

- Added `/audioplayer stop (sound)` to commands
- Added `findChannelID` class so that the command can use `sound` to search for `ChannelID` using the same `sound` and stops it with the` stop` class.

There are some potential issues such as when the same _sound_ is being played at the same time, can't currently specify which one stops. 

Could add optional `pos` argument in the future to specify coordinates.

Thanks for making an awesome mod, enjoyed making my first ever contribution.