### PR TITLE
Feature: filename Subcommand

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,13 +53,17 @@ Run `/audioplayer filebin` and follow the instructions.
 **Putting custom audio on a music disc or goat horn**
 
 Run `/audioplayer apply <ID>` and hold a **music disc**, **goat horn** or **head** in your main hand.
-Additionally, you can add a custom name and range to the item `/audioplayer apply <ID> "<CUSTOM-TEXT>" <RANGE>`.
+Additionally, you can add a custom name and range to the item `/audioplayer apply <ID> <RANGE> "<CUSTOM-TEXT>"`.
 
 It's also possible to bulk apply audio to more than one item at a time by holding a shulker box in your hand.
 
 **Getting the audio from an existing item**
 
 Run `/audioplayer id` and hold a music disc or a goat horn with custom audio in your main hand.
+
+**Getting the original filename from an existing item**
+
+Run `/audioplayer filename` and hold a music disc or a goat horn with custom audio in your main hand.
 
 ---
 [![](https://user-images.githubusercontent.com/13237524/179395180-05f2ec3b-2ed3-412d-8639-72c7f13a8068.png)](https://youtu.be/j8GRcYnjUp8)

--- a/src/main/java/de/maxhenkel/audioplayer/Filebin.java
+++ b/src/main/java/de/maxhenkel/audioplayer/Filebin.java
@@ -62,6 +62,7 @@ public class Filebin {
 
                 String filename = file.get("filename").getAsString();
                 AudioManager.saveSound(server, sound, url + "/" + filename);
+                FilenameMappings.append(server, filename, sound);
                 return;
             }
         }

--- a/src/main/java/de/maxhenkel/audioplayer/FilenameMappings.java
+++ b/src/main/java/de/maxhenkel/audioplayer/FilenameMappings.java
@@ -1,0 +1,87 @@
+package de.maxhenkel.audioplayer;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.UUID;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.server.MinecraftServer;
+
+public class FilenameMappings {
+
+    public static void append(MinecraftServer server, String filename, UUID sound) {
+        URI location = server.getWorldPath(AudioManager.AUDIO_DATA).resolve("filename_mappings.dat").toUri();
+        File mappingsFile = new File(location);
+        String extension = filename.substring(filename.length() - 4);
+
+        try {
+            CompoundTag root = loadOrDefault(mappingsFile);
+            ListTag mappings = getMappingListOrDefault(root);
+
+            CompoundTag entry = new CompoundTag();
+            entry.putString("uuid", sound.toString() + extension);
+            entry.putString("filename", filename);
+
+            mappings.add(entry);
+
+            if (!root.contains("mappings")) {
+                root.put("mappings", mappings);
+            }
+
+            NbtIo.writeCompressed(root, mappingsFile.toPath());
+        } catch (IOException e) {
+            System.err.println("Permission Denied. Failed to read or write the file.");
+        }
+
+        verifyFilesExist(server);
+    }
+
+    public static void verifyFilesExist(MinecraftServer server) {
+        URI location = server.getWorldPath(AudioManager.AUDIO_DATA).resolve("filename_mappings.dat").toUri();
+        File mappingsFile = new File(location);
+
+        try {
+            CompoundTag root = loadOrDefault(mappingsFile);
+            ListTag mappings = getMappingListOrDefault(root);
+
+            for (int i = 0; i < mappings.size(); i++) {
+                String uuid = mappings.getCompound(i).getString("uuid");
+                URI filepath = server.getWorldPath(AudioManager.AUDIO_DATA).resolve(uuid).toUri();
+
+                if (!new File(filepath).exists()) {
+                    mappings.remove(i);
+                }
+            }
+
+            NbtIo.writeCompressed(root, mappingsFile.toPath());
+
+            if (mappings.isEmpty()) {
+                mappingsFile.delete();
+            }
+        } catch (IOException e) {
+            System.err.println("Permission Denied. Failed to read or write the file.");
+        }
+    }
+
+    public static void autoSaveHappened() {
+        AudioPlayer.LOGGER.warn("Auto Save Triggered!");
+    }
+
+    private static CompoundTag loadOrDefault(File filepath) throws IOException {
+        if (filepath.exists()) {
+            return NbtIo.readCompressed(filepath.toPath(), NbtAccounter.unlimitedHeap());
+        }
+        return new CompoundTag();
+    }
+
+    private static ListTag getMappingListOrDefault(CompoundTag tag) {
+        if (tag.contains("mappings")) {
+            return (ListTag) tag.get("mappings");
+        }
+        return new ListTag();
+    }
+}

--- a/src/main/java/de/maxhenkel/audioplayer/command/UploadCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/UploadCommands.java
@@ -7,6 +7,7 @@ import de.maxhenkel.admiral.annotations.RequiresPermission;
 import de.maxhenkel.audioplayer.AudioManager;
 import de.maxhenkel.audioplayer.AudioPlayer;
 import de.maxhenkel.audioplayer.Filebin;
+import de.maxhenkel.audioplayer.FilenameMappings;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.chat.*;
@@ -144,6 +145,7 @@ public class UploadCommands {
                 context.getSource().sendFailure(Component.literal("Failed to download sound: %s".formatted(e.getMessage())));
             }
         }).start();
+        FilenameMappings.append(context.getSource().getServer(), url.split("/")[url.split("/").length - 1], sound);
     }
 
     @RequiresPermission("audioplayer.upload")
@@ -201,6 +203,7 @@ public class UploadCommands {
                 context.getSource().sendFailure(Component.literal("Failed to copy sound: %s".formatted(e.getMessage())));
             }
         }).start();
+        FilenameMappings.append(context.getSource().getServer(), fileName, uuid);
     }
 
     public static MutableComponent sendUUIDMessage(UUID soundID, MutableComponent component) {

--- a/src/main/java/de/maxhenkel/audioplayer/command/UtilityCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/UtilityCommands.java
@@ -1,14 +1,27 @@
 package de.maxhenkel.audioplayer.command;
 
+import java.io.File;
+import java.io.IOException;
+
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import de.maxhenkel.admiral.annotations.Command;
 import de.maxhenkel.admiral.annotations.RequiresPermission;
+import de.maxhenkel.audioplayer.AudioManager;
 import de.maxhenkel.audioplayer.CustomSound;
+import de.maxhenkel.audioplayer.FilenameMappings;
 import de.maxhenkel.audioplayer.PlayerType;
+import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.InstrumentItem;
@@ -75,4 +88,67 @@ public class UtilityCommands {
         context.getSource().sendSuccess(() -> UploadCommands.sendUUIDMessage(customSound.getSoundId(), Component.literal("Successfully extracted sound ID.")), false);
     }
 
+    @Command("filename")
+    public void filename(CommandContext<CommandSourceStack> context) throws CommandSyntaxException, IOException {
+        ServerPlayer player = context.getSource().getPlayerOrException();
+        ItemStack itemInHand = player.getItemInHand(InteractionHand.MAIN_HAND);
+
+        PlayerType playerType = PlayerType.fromItemStack(itemInHand);
+
+        if (playerType == null) {
+            context.getSource().sendFailure(Component.literal("Invalid item"));
+            return;
+        }
+
+        CustomSound customSound = CustomSound.of(itemInHand);
+        if (customSound == null) {
+            context.getSource().sendFailure(Component.literal("Item does not have custom audio"));
+            return;
+        }
+
+        String soundId = customSound.getSoundId().toString();
+
+        MinecraftServer server = player.getCommandSenderWorld().getServer();
+
+        File mappingsFile = new File(server.getWorldPath(AudioManager.AUDIO_DATA).resolve("filename_mappings.dat").toUri());
+
+        if (!mappingsFile.exists()) {
+            context.getSource().sendFailure(Component.literal(
+                "Item has custom audio but filename was not saved when it was created. "+
+                "It may have been created in an older version of the AudioPlayer mod.")
+            );
+            return;
+        }
+
+        CompoundTag root = NbtIo.readCompressed(mappingsFile.toPath(), NbtAccounter.unlimitedHeap());
+        ListTag mappings = (ListTag) root.get("mappings");
+
+        for (int i = 0; i < mappings.size(); i++) {
+            CompoundTag entry = mappings.getCompound(i);
+            String uuid = entry.getString("uuid").replaceAll(".wav|.mp3", "");
+
+            if (uuid.equals(soundId)) {
+                String filename = entry.getString("filename");
+
+                MutableComponent msg = Component.literal("Successfully retrieved sound Filename. ")
+                    .append(Component.literal("[Copy Filename]")
+                        .withStyle(style -> {
+                            return style
+                                .withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, filename))
+                                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal("Copy sound Filename")));
+                        })
+                        .withStyle(ChatFormatting.GREEN)
+                    );
+
+                context.getSource().sendSuccess(() -> msg, false);
+                FilenameMappings.verifyFilesExist(server);
+                return;
+            }
+        }
+
+        context.getSource().sendFailure(Component.literal(
+            "Failed to retrieved sound filename.\n"+
+            "If you updated from an older version of the mod, existing sounds won't be able to retrieve the original filenames."
+        ));
+    }
 }


### PR DESCRIPTION
This pull request introduces a new `filename` subcommand to `/audioplayer`.

### Overview

It operates by utilizing a new file named `filename_mappings.dat`, which resides in the existing `audio_player_data` folder of the world. This file is structured as a GZipped NBT file, containing a list of mappings between original filenames and their corresponding UUID names.

### File Structure

The structure of `filename_mappings.dat` is as follows:

```
TAG_Compound(): {
    TAG_List("mappings"): {
        TAG_Compound(): {
            TAG_String("filename"): "<Original filename>.<extension>",
            TAG_String("uuid"): "<UUID>.<extension>"
        },
        ...
    }
}
```

### Functionality

Whenever a new audio file is uploaded, regardless of the method used, an entry is added to `filename_mappings.dat`. Conversely, if a file is deleted the mappings associated with that file will be removed the next time the `filename` command is ran or when another audio file is uploaded.

### Motivation

I implemented this feature to enhance the usability and maintainability of the users audio files. By introducing the `filename` subcommand and associated functionality, users can easily manage audio file mappings, whether its with the command itself for a couple of files or externally with user made scripts for a larger number of files.
