### PR TITLE
Add volume command for server side volume adjustment

### DIFF
--- a/src/main/java/de/maxhenkel/audioplayer/AudioCache.java
+++ b/src/main/java/de/maxhenkel/audioplayer/AudioCache.java
@@ -26,6 +26,11 @@ public class AudioCache {
         return data;
     }
 
+    public synchronized void remove(UUID id) {
+        audioCache.remove(id);
+        accessQueue.remove(id);
+    }
+
     private void pushCache(UUID id, short[] data) {
         if (size <= 0) {
             return;

--- a/src/main/java/de/maxhenkel/audioplayer/AudioConverter.java
+++ b/src/main/java/de/maxhenkel/audioplayer/AudioConverter.java
@@ -75,16 +75,11 @@ public class AudioConverter {
     }
 
     private static short[] convert(AudioInputStream source, float volume) throws IOException {
-        long startTime = System.nanoTime();
         AudioFormat sourceFormat = source.getFormat();
         AudioFormat convertFormat = new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, sourceFormat.getSampleRate(), 16, sourceFormat.getChannels(), sourceFormat.getChannels() * 2, sourceFormat.getSampleRate(), false);
         AudioInputStream stream1 = AudioSystem.getAudioInputStream(convertFormat, source);
         AudioInputStream stream2 = AudioSystem.getAudioInputStream(FORMAT, stream1);
-        short[] rval = Plugin.voicechatApi.getAudioConverter().bytesToShorts(adjustVolume(stream2.readAllBytes(),volume));
-        long endTime = System.nanoTime();
-        long durationMillis = (endTime - startTime) / 1000000;
-        AudioPlayer.LOGGER.info("Converting took, {}", durationMillis);
-        return rval;
+        return Plugin.voicechatApi.getAudioConverter().bytesToShorts(adjustVolume(stream2.readAllBytes(),volume));
     }
 
     private static byte[] adjustVolume(byte[] audioSamples, float volume) {

--- a/src/main/java/de/maxhenkel/audioplayer/AudioConverter.java
+++ b/src/main/java/de/maxhenkel/audioplayer/AudioConverter.java
@@ -55,34 +55,57 @@ public class AudioConverter {
         }
     }
 
-    public static short[] convert(Path file) throws IOException, UnsupportedAudioFileException {
-        return convert(file, getAudioType(file));
+    public static short[] convert(Path file, float volume) throws IOException, UnsupportedAudioFileException {
+        return convert(file, getAudioType(file), volume);
     }
 
-    public static short[] convert(Path file, AudioType audioType) throws IOException, UnsupportedAudioFileException {
+    public static short[] convert(Path file, AudioType audioType, float volume) throws IOException, UnsupportedAudioFileException {
         if (audioType == AudioType.WAV) {
-            return convertWav(file);
+            return convertWav(file, volume);
         } else if (audioType == AudioType.MP3) {
-            return convertMp3(file);
+            return convertMp3(file, volume);
         }
         throw new UnsupportedAudioFileException("Unsupported audio type");
     }
 
-    public static short[] convertWav(Path file) throws IOException, UnsupportedAudioFileException {
+    public static short[] convertWav(Path file, float volume) throws IOException, UnsupportedAudioFileException {
         try (AudioInputStream source = AudioSystem.getAudioInputStream(file.toFile())) {
-            return convert(source);
+            return convert(source, volume);
         }
     }
 
-    private static short[] convert(AudioInputStream source) throws IOException {
+    private static short[] convert(AudioInputStream source, float volume) throws IOException {
+        long startTime = System.nanoTime();
         AudioFormat sourceFormat = source.getFormat();
         AudioFormat convertFormat = new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, sourceFormat.getSampleRate(), 16, sourceFormat.getChannels(), sourceFormat.getChannels() * 2, sourceFormat.getSampleRate(), false);
         AudioInputStream stream1 = AudioSystem.getAudioInputStream(convertFormat, source);
         AudioInputStream stream2 = AudioSystem.getAudioInputStream(FORMAT, stream1);
-        return Plugin.voicechatApi.getAudioConverter().bytesToShorts(stream2.readAllBytes());
+        short[] rval = Plugin.voicechatApi.getAudioConverter().bytesToShorts(adjustVolume(stream2.readAllBytes(),volume));
+        long endTime = System.nanoTime();
+        long durationMillis = (endTime - startTime) / 1000000;
+        AudioPlayer.LOGGER.info("Converting took, {}", durationMillis);
+        return rval;
     }
 
-    public static short[] convertMp3(Path file) throws IOException, UnsupportedAudioFileException {
+    private static byte[] adjustVolume(byte[] audioSamples, float volume) {
+        for (int i = 0; i < audioSamples.length; i+=2) {
+            short buf1 = audioSamples[i+1];
+            short buf2 = audioSamples[i];
+
+            buf1 = (short) ((buf1 & 0xff) << 8);
+            buf2 = (short) (buf2 & 0xff);
+
+            short res= (short) (buf1 | buf2);
+            res = (short) (res * volume);
+
+            audioSamples[i] = (byte) res;
+            audioSamples[i+1] = (byte) (res >> 8);
+
+        }
+        return audioSamples;
+    }
+
+    public static short[] convertMp3(Path file, float volume) throws IOException, UnsupportedAudioFileException {
         try {
             Mp3Decoder mp3Decoder = Plugin.voicechatApi.createMp3Decoder(Files.newInputStream(file));
             if (mp3Decoder == null) {
@@ -92,10 +115,10 @@ public class AudioConverter {
             ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(data);
             AudioFormat audioFormat = mp3Decoder.getAudioFormat();
             AudioInputStream source = new AudioInputStream(byteArrayInputStream, audioFormat, data.length / audioFormat.getFrameSize());
-            return convert(source);
+            return convert(source, volume);
         } catch (Exception e) {
             AudioPlayer.LOGGER.warn("Error converting mp3 file with native decoder");
-            return convert(AudioSystem.getAudioInputStream(file.toFile()));
+            return convert(AudioSystem.getAudioInputStream(file.toFile()),volume);
         }
     }
 

--- a/src/main/java/de/maxhenkel/audioplayer/AudioManager.java
+++ b/src/main/java/de/maxhenkel/audioplayer/AudioManager.java
@@ -27,7 +27,13 @@ public class AudioManager {
     public static LevelResource AUDIO_DATA = new LevelResource("audio_player_data");
 
     public static short[] getSound(MinecraftServer server, UUID id) throws Exception {
-        return AudioPlayer.AUDIO_CACHE.get(id, () -> AudioConverter.convert(getExistingSoundFile(server, id)));
+        float volume;
+        if (VolumeOverrideManager.instance().isPresent()) {
+            volume = VolumeOverrideManager.instance().get().getAudioVolume(id);
+        } else {
+            volume = 1.0f;
+        }
+        return AudioPlayer.AUDIO_CACHE.get(id, () -> AudioConverter.convert(getExistingSoundFile(server, id),volume));
     }
 
     public static Path getSoundFile(MinecraftServer server, UUID id, String extension) {
@@ -48,6 +54,15 @@ public class AudioManager {
             return file;
         }
         throw new FileNotFoundException("Audio does not exist");
+    }
+
+    public static boolean checkSoundExists(MinecraftServer server, UUID id) {
+        Path file = getSoundFile(server, id, AudioConverter.AudioType.MP3.getExtension());
+        if (Files.exists(file)) {
+            return true;
+        }
+        file = getSoundFile(server, id, AudioConverter.AudioType.WAV.getExtension());
+        return Files.exists(file);
     }
 
     public static Path getUploadFolder() {

--- a/src/main/java/de/maxhenkel/audioplayer/AudioPlayer.java
+++ b/src/main/java/de/maxhenkel/audioplayer/AudioPlayer.java
@@ -1,10 +1,7 @@
 package de.maxhenkel.audioplayer;
 
 import de.maxhenkel.admiral.MinecraftAdmiral;
-import de.maxhenkel.audioplayer.command.ApplyCommands;
-import de.maxhenkel.audioplayer.command.PlayCommands;
-import de.maxhenkel.audioplayer.command.UploadCommands;
-import de.maxhenkel.audioplayer.command.UtilityCommands;
+import de.maxhenkel.audioplayer.command.*;
 import de.maxhenkel.audioplayer.config.ServerConfig;
 import de.maxhenkel.audioplayer.config.WebServerConfig;
 import de.maxhenkel.audioplayer.webserver.WebServerEvents;
@@ -49,7 +46,7 @@ public class AudioPlayer implements ModInitializer {
                     PlayCommands.class
             ).setPermissionManager(AudioPlayerPermissionManager.INSTANCE).build();
         });
-
+        VolumeOverrideManager.init();
         FileNameManager.init();
         Path configFolder = FabricLoader.getInstance().getConfigDir().resolve(MODID);
         SERVER_CONFIG = ConfigBuilder.builder(ServerConfig::new).path(configFolder.resolve("audioplayer-server.properties")).build();

--- a/src/main/java/de/maxhenkel/audioplayer/AudioPlayerPermissionManager.java
+++ b/src/main/java/de/maxhenkel/audioplayer/AudioPlayerPermissionManager.java
@@ -14,6 +14,7 @@ public class AudioPlayerPermissionManager implements PermissionManager<CommandSo
 
     public static final AudioPlayerPermissionManager INSTANCE = new AudioPlayerPermissionManager();
 
+    private static final Permission VOLUME_PERMISSION = new Permission("audioplayer.volume", PermissionType.EVERYONE);
     private static final Permission UPLOAD_PERMISSION = new Permission("audioplayer.upload", PermissionType.EVERYONE);
     private static final Permission APPLY_PERMISSION = new Permission("audioplayer.apply", PermissionType.EVERYONE);
     private static final Permission APPLY_ANNOUNCER_PERMISSION = new AnnouncerPermission("audioplayer.set_static", PermissionType.EVERYONE);
@@ -23,7 +24,8 @@ public class AudioPlayerPermissionManager implements PermissionManager<CommandSo
             UPLOAD_PERMISSION,
             APPLY_PERMISSION,
             APPLY_ANNOUNCER_PERMISSION,
-            PLAY_COMMAND_PERMISSION
+            PLAY_COMMAND_PERMISSION,
+            VOLUME_PERMISSION
     );
 
     @Override

--- a/src/main/java/de/maxhenkel/audioplayer/VolumeOverrideManager.java
+++ b/src/main/java/de/maxhenkel/audioplayer/VolumeOverrideManager.java
@@ -1,0 +1,111 @@
+package de.maxhenkel.audioplayer;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+
+import javax.annotation.Nullable;
+import java.io.*;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+public class VolumeOverrideManager {
+
+    private final File file;
+    private final Gson gson;
+    private Map<UUID, Float> volumes;
+
+    public VolumeOverrideManager(File file) {
+        this.file = file;
+        this.gson = new GsonBuilder().create();
+        this.volumes = new HashMap<>();
+        load();
+    }
+
+    public void load() {
+        if (!file.exists()) {
+            return;
+        }
+        try (Reader reader = new FileReader(file)) {
+            Type fileNameMapType = new TypeToken<Map<UUID, Float>>() {
+            }.getType();
+            volumes = gson.fromJson(reader, fileNameMapType);
+        } catch (Exception e) {
+            AudioPlayer.LOGGER.error("Failed to load volume overrides", e);
+        }
+        if (volumes == null) {
+            volumes = new HashMap<>();
+        }
+        save();
+    }
+
+    public void save() {
+        file.getParentFile().mkdirs();
+        try (Writer writer = new FileWriter(file)) {
+            gson.toJson(volumes, writer);
+        } catch (Exception e) {
+            AudioPlayer.LOGGER.error("Failed to save file name mappings", e);
+        }
+    }
+
+    /**
+     * Gets the volume override associated with the provided sound ID, or 1.0f if there is no override set
+     *
+     * @param audioId  the audio ID
+     */
+    @Nullable
+    public Float getAudioVolume(UUID audioId) {
+        return volumes.getOrDefault(audioId, 1.0f);
+    }
+
+    /**
+     * Sets the volume override associated with the provided ID, removes override if the volume is <code>null</code>
+     *
+     * @param audioId  the audio ID
+     * @param volume the file name or <code>null</code>
+     */
+    public void setAudioVolume(UUID audioId, @Nullable Float volume) {
+        if (volume == null) {
+            volumes.remove(audioId);
+            //TODO Save off-thread
+            save();
+            return;
+        }
+        volumes.put(audioId, volume);
+        //TODO Save off-thread
+        save();
+    }
+
+    @Nullable
+    private static VolumeOverrideManager INSTANCE;
+
+    public static void init() {
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+            AudioPlayer.LOGGER.info("Loading audio file volume overrides...");
+            Path audioDataFolder = AudioManager.getAudioDataFolder(server);
+            if (Files.exists(audioDataFolder)) {
+                try {
+                    Files.createDirectories(audioDataFolder);
+                } catch (IOException e) {
+                    AudioPlayer.LOGGER.error("Failed to create audio data folder", e);
+                    return;
+                }
+            }
+            INSTANCE = new VolumeOverrideManager(audioDataFolder.resolve("volume-overrides.json").toFile());
+        });
+        ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
+            INSTANCE = null;
+        });
+    }
+
+    public static Optional<VolumeOverrideManager> instance() {
+        return Optional.ofNullable(INSTANCE);
+    }
+
+}

--- a/src/main/java/de/maxhenkel/audioplayer/command/ApplyCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/ApplyCommands.java
@@ -29,7 +29,7 @@ public class ApplyCommands {
 
     @RequiresPermission("audioplayer.apply")
     @Command("apply")
-    public void apply(CommandContext<CommandSourceStack> context, @Name("file_name") String fileName, @OptionalArgument @Name("range") @Min("1") Float range, @OptionalArgument @Name("custom_name") String customName) throws CommandSyntaxException {
+    public void apply(CommandContext<CommandSourceStack> context, @Name("file_name") String fileName, @OptionalArgument @Name("range") @Min("1") Float range, @OptionalArgument @Name("custom_name") String customName, @OptionalArgument @Name("channel") String channelId) throws CommandSyntaxException {
         UUID id = getId(context, fileName);
         if (id == null) {
             return;
@@ -39,7 +39,7 @@ public class ApplyCommands {
 
     @RequiresPermission("audioplayer.apply")
     @Command("apply")
-    public void apply(CommandContext<CommandSourceStack> context, @Name("file_name") String fileName, @OptionalArgument @Name("custom_name") String customName) throws CommandSyntaxException {
+    public void apply(CommandContext<CommandSourceStack> context, @Name("file_name") String fileName, @OptionalArgument @Name("custom_name") String customName, @OptionalArgument @Name("channel") String channelId) throws CommandSyntaxException {
         UUID id = getId(context, fileName);
         if (id == null) {
             return;


### PR DESCRIPTION
Adds a basic volume command to adjust volume of audio files, syntax

`/audioplayer volume <id> <volume>` to adjust a specific id
`/audioplayer volume <volume>` to adjust the held item
`/audioplayer volume <id>` to get the volume of a audio id
`/audioplayer volume` to get thhe volume of a held item

requires permission `audioplayer.volume` which is enabled by default