### PR TITLE
Feature: multiple sounds on one item (randomized playback)

### DIFF
--- a/src/main/java/de/maxhenkel/audioplayer/CustomSound.java
+++ b/src/main/java/de/maxhenkel/audioplayer/CustomSound.java
@@ -4,6 +4,9 @@ import de.maxhenkel.configbuilder.entry.ConfigEntry;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtUtils;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.Unit;
 import net.minecraft.world.item.BlockItem;
@@ -84,10 +87,7 @@ public class CustomSound {
     public ArrayList<UUID> getRandomSounds() { return randomSounds;  }
 
     public void addRandomSound(UUID id) {
-        if (randomSounds == null) {
-            randomSounds = new ArrayList<>();
-            randomSounds.add(soundId);
-        }
+        setRandomization(true);
         randomSounds.add(id);
     }
 
@@ -148,24 +148,18 @@ public class CustomSound {
     }
 
     public static void saveUUIDArrayToNbt(CompoundTag tag, String id, List<UUID> uuids) {
-        List<Long> uuidList = new ArrayList<>();
+        ListTag uuidList = new ListTag();
         for (UUID uuid : uuids) {
-            uuidList.add(uuid.getMostSignificantBits());
-            uuidList.add(uuid.getLeastSignificantBits());
+            uuidList.add(NbtUtils.createUUID(uuid));
         }
-        tag.putLongArray(id,uuidList);
+        tag.put(id, uuidList);
     }
 
     public static ArrayList<UUID> readUUIDArrayFromNbt(CompoundTag tag, String id) {
-        long[] uuids = tag.getLongArray(id);
-        if (uuids.length % 2 != 0) {
-            throw new IllegalArgumentException("Invalid UUID array length: " + uuids.length);
-        }
-        ArrayList<UUID> uuidList = new ArrayList<>(uuids.length/2);
-        for (int i = 0; i < uuids.length; i += 2) {
-            long msb = uuids[i];
-            long lsb = uuids[i+1];
-            uuidList.add(new UUID(msb, lsb));
+        ListTag list = tag.getList(id, Tag.TAG_INT_ARRAY);
+        ArrayList<UUID> uuidList = new ArrayList<>(list.size());
+        for (Tag value : list) {
+            uuidList.add(NbtUtils.loadUUID(value));
         }
         return uuidList;
     }

--- a/src/main/java/de/maxhenkel/audioplayer/command/ApplyCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/ApplyCommands.java
@@ -26,7 +26,6 @@ import java.util.UUID;
 
 @Command("audioplayer")
 public class ApplyCommands {
-
     @RequiresPermission("audioplayer.apply")
     @Command("apply")
     public void apply(CommandContext<CommandSourceStack> context, @Name("file_name") String fileName, @OptionalArgument @Name("range") @Min("1") Float range, @OptionalArgument @Name("custom_name") String customName) throws CommandSyntaxException {
@@ -34,7 +33,7 @@ public class ApplyCommands {
         if (id == null) {
             return;
         }
-        apply(context, new CustomSound(id, range, false), customName);
+        apply(context, new CustomSound(id, range, null, false), customName);
     }
 
     @RequiresPermission("audioplayer.apply")
@@ -44,7 +43,7 @@ public class ApplyCommands {
         if (id == null) {
             return;
         }
-        apply(context, new CustomSound(id, null, false), customName);
+        apply(context, new CustomSound(id, null, null, false), customName);
     }
 
     // The apply commands for UUIDs must be below the ones with file names, so that the file name does not overwrite the UUID argument
@@ -54,7 +53,7 @@ public class ApplyCommands {
     @Command("musicdisc")
     @Command("goathorn")
     public void apply(CommandContext<CommandSourceStack> context, @Name("sound_id") UUID sound, @OptionalArgument @Name("range") @Min("1") Float range, @OptionalArgument @Name("custom_name") String customName) throws CommandSyntaxException {
-        apply(context, new CustomSound(sound, range, false), customName);
+        apply(context, new CustomSound(sound, range, null, false), customName);
     }
 
     @RequiresPermission("audioplayer.apply")
@@ -62,7 +61,7 @@ public class ApplyCommands {
     @Command("musicdisc")
     @Command("goathorn")
     public void apply(CommandContext<CommandSourceStack> context, @Name("sound_id") UUID sound, @OptionalArgument @Name("custom_name") String customName) throws CommandSyntaxException {
-        apply(context, new CustomSound(sound, null, false), customName);
+        apply(context, new CustomSound(sound, null,null, false), customName);
     }
 
     @Nullable
@@ -159,7 +158,6 @@ public class ApplyCommands {
         if (!type.isValid(stack)) {
             return;
         }
-        customSound.saveToItem(stack, customName);
 
         if (stack.has(DataComponents.INSTRUMENT)) {
             stack.set(DataComponents.INSTRUMENT, ComponentUtils.EMPTY_INSTRUMENT);
@@ -168,7 +166,16 @@ public class ApplyCommands {
             stack.set(DataComponents.JUKEBOX_PLAYABLE, ComponentUtils.CUSTOM_JUKEBOX_PLAYABLE);
         }
 
-        context.getSource().sendSuccess(() -> Component.literal("Successfully updated ").append(stack.getHoverName()), false);
+        CustomSound handItemSound = CustomSound.of(stack);
+
+        if (handItemSound != null && handItemSound.isRandomized()) {
+            handItemSound.addRandomSound(customSound.getSoundId());
+            handItemSound.saveToItem(stack, customName);
+            context.getSource().sendSuccess(() -> Component.literal("Successfully added sound to ").append(stack.getHoverName()), false);
+        } else {
+            customSound.saveToItem(stack, customName);
+            context.getSource().sendSuccess(() -> Component.literal("Successfully updated ").append(stack.getHoverName()), false);
+        }
     }
 
     private static void checkRange(ConfigEntry<Float> maxRange, @Nullable Float range) throws CommandSyntaxException {

--- a/src/main/java/de/maxhenkel/audioplayer/command/UtilityCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/UtilityCommands.java
@@ -16,10 +16,39 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.*;
 
+import java.util.ArrayList;
 import java.util.Optional;
+import java.util.UUID;
 
 @Command("audioplayer")
 public class UtilityCommands {
+    @Command("set_random")
+    public void set_random(CommandContext<CommandSourceStack> context, @Name("enabled") boolean enabled) throws CommandSyntaxException {
+        ServerPlayer player = context.getSource().getPlayerOrException();
+        ItemStack itemInHand = player.getItemInHand(InteractionHand.MAIN_HAND);
+
+        PlayerType playerType = PlayerType.fromItemStack(itemInHand);
+        if (playerType == null) {
+            context.getSource().sendFailure(Component.nullToEmpty("Invalid Item"));
+            return;
+        }
+
+        CustomSound sound = getHeldSound(context);
+
+        if (sound == null) {
+            return;
+        }
+
+        sound.setRandomization(enabled);
+
+        sound.saveToItem(itemInHand,null,false);
+
+        if (enabled) {
+            context.getSource().sendSuccess(() -> Component.literal("Successfully enabled randomization, more sounds can now be added to this item"), false);
+        } else {
+            context.getSource().sendSuccess(() -> Component.literal("Successfully disabled randomization, extra sounds have been removed"), false);
+        }
+    }
 
     @RequiresPermission("audioplayer.apply")
     @Command("clear")
@@ -68,6 +97,15 @@ public class UtilityCommands {
         if (customSound == null) {
             return;
         }
+        if (customSound.isRandomized()) {
+            ArrayList<UUID> sounds = customSound.getRandomSounds();
+            context.getSource().sendSuccess(() -> Component.literal("Item contains %d sounds".formatted(sounds.size())),false);
+            for (int i = 0; i < sounds.size(); i++) {
+                int finalI = i;
+                context.getSource().sendSuccess(() -> UploadCommands.sendUUIDMessage(sounds.get(finalI), Component.literal("Sound %d.".formatted(finalI))), false);
+            }
+            return;
+        }
         context.getSource().sendSuccess(() -> UploadCommands.sendUUIDMessage(customSound.getSoundId(), Component.literal("Successfully extracted sound ID.")), false);
     }
 
@@ -81,6 +119,27 @@ public class UtilityCommands {
 
         if (optionalMgr.isEmpty()) {
             context.getSource().sendFailure(Component.literal("An internal error occurred"));
+            return;
+        }
+
+        if (customSound.isRandomized()) {
+            ArrayList<UUID> sounds = customSound.getRandomSounds();
+            context.getSource().sendSuccess(() -> Component.literal("Item contains %d sounds".formatted(sounds.size())),false);
+            for (int i = 0; i < sounds.size(); i++) {
+                FileNameManager mgr = optionalMgr.get();
+                String fileName = mgr.getFileName(sounds.get(i));
+                if (fileName == null) {
+                    context.getSource().sendFailure(Component.literal("Custom audio does not have an associated file name"));
+                    return;
+                }
+
+                context.getSource().sendSuccess(() -> Component.literal("Audio file name: ").append(Component.literal(fileName).withStyle(style -> {
+                    return style
+                            .withColor(ChatFormatting.GREEN)
+                            .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy")))
+                            .withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, fileName));
+                })), false);
+            }
             return;
         }
 

--- a/src/main/java/de/maxhenkel/audioplayer/command/UtilityCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/UtilityCommands.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 
 @Command("audioplayer")
 public class UtilityCommands {
+    @RequiresPermission("audioplayer.apply")
     @Command("set_random")
     public void set_random(CommandContext<CommandSourceStack> context, @Name("enabled") boolean enabled) throws CommandSyntaxException {
         ServerPlayer player = context.getSource().getPlayerOrException();
@@ -122,29 +123,22 @@ public class UtilityCommands {
             return;
         }
 
+        FileNameManager mgr = optionalMgr.get();
+
         if (customSound.isRandomized()) {
             ArrayList<UUID> sounds = customSound.getRandomSounds();
             context.getSource().sendSuccess(() -> Component.literal("Item contains %d sounds".formatted(sounds.size())),false);
-            for (int i = 0; i < sounds.size(); i++) {
-                FileNameManager mgr = optionalMgr.get();
-                String fileName = mgr.getFileName(sounds.get(i));
-                if (fileName == null) {
-                    context.getSource().sendFailure(Component.literal("Custom audio does not have an associated file name"));
-                    return;
-                }
-
-                context.getSource().sendSuccess(() -> Component.literal("Audio file name: ").append(Component.literal(fileName).withStyle(style -> {
-                    return style
-                            .withColor(ChatFormatting.GREEN)
-                            .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy")))
-                            .withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, fileName));
-                })), false);
+            for (UUID sound : sounds) {
+                sendSoundName(context,mgr,sound);
             }
             return;
         }
 
-        FileNameManager mgr = optionalMgr.get();
-        String fileName = mgr.getFileName(customSound.getSoundId());
+        sendSoundName(context,mgr,customSound.getSoundId());
+    }
+
+    public static void sendSoundName(CommandContext<CommandSourceStack> context, FileNameManager mgr, UUID id) {
+        String fileName = mgr.getFileName(id);
         if (fileName == null) {
             context.getSource().sendFailure(Component.literal("Custom audio does not have an associated file name"));
             return;

--- a/src/main/java/de/maxhenkel/audioplayer/command/VolumeCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/VolumeCommands.java
@@ -27,6 +27,12 @@ public class VolumeCommands {
         if (customSound == null) {
             return;
         }
+        if (customSound.isRandomized()) {
+            for (UUID id : customSound.getRandomSounds()) {
+                volumeCommand(context, id, volume);
+            }
+            return;
+        }
         volumeCommand(context, customSound.getSoundId(), volume);
     }
 


### PR DESCRIPTION
feature works as is, draft created for discussion of user experince of implementation 

currently /audioplayer apply works as is normally, but if the item has randomized sound enabled it adds the sound instead

randomised sound has to be enabled for an item with /audioplayer set_random after the first sound has been added

name and id subcommands have been updated to report all sounds on an item with random sound, and clear clears it aswell

