### PR TITLE
update volume command to log volume percent, to make it perceptually linear

### DIFF
--- a/src/main/java/de/maxhenkel/audioplayer/VolumeOverrideManager.java
+++ b/src/main/java/de/maxhenkel/audioplayer/VolumeOverrideManager.java
@@ -107,4 +107,20 @@ public class VolumeOverrideManager {
         return Optional.ofNullable(INSTANCE);
     }
 
+    private static final float LOG_BASE = 2.0f;
+
+    public static float convertToLinearScaleFactor(float logarithmicScaleFactor) {
+        if (logarithmicScaleFactor <= 0) {
+            return 0;
+        }
+
+        return 1 + (float) (Math.log10(logarithmicScaleFactor) / LOG_BASE);
+    }
+
+    public static float convertToLogarithmicScaleFactor(float linearScaleFactor) {
+        linearScaleFactor = Math.max(0, Math.min(linearScaleFactor, 1));
+
+        return (float) Math.pow(10, (linearScaleFactor - 1) * LOG_BASE);
+    }
+
 }

--- a/src/main/java/de/maxhenkel/audioplayer/VolumeOverrideManager.java
+++ b/src/main/java/de/maxhenkel/audioplayer/VolumeOverrideManager.java
@@ -107,20 +107,20 @@ public class VolumeOverrideManager {
         return Optional.ofNullable(INSTANCE);
     }
 
-    private static final float LOG_BASE = 2.0f;
+    private static final float LOG_BASE = 2F;
 
     public static float convertToLinearScaleFactor(float logarithmicScaleFactor) {
-        if (logarithmicScaleFactor <= 0) {
-            return 0;
+        if (logarithmicScaleFactor <= 0F) {
+            return 0F;
         }
 
-        return 1 + (float) (Math.log10(logarithmicScaleFactor) / LOG_BASE);
+        return 1F + (float) (Math.log10(logarithmicScaleFactor) / LOG_BASE);
     }
 
     public static float convertToLogarithmicScaleFactor(float linearScaleFactor) {
-        linearScaleFactor = Math.max(0, Math.min(linearScaleFactor, 1));
+        linearScaleFactor = Math.max(0F, Math.min(linearScaleFactor, 1F));
 
-        return (float) Math.pow(10, (linearScaleFactor - 1) * LOG_BASE);
+        return (float) Math.pow(10D, (linearScaleFactor - 1F) * LOG_BASE);
     }
 
 }

--- a/src/main/java/de/maxhenkel/audioplayer/command/VolumeCommands.java
+++ b/src/main/java/de/maxhenkel/audioplayer/command/VolumeCommands.java
@@ -56,7 +56,7 @@ public class VolumeCommands {
             context.getSource().sendSuccess(() -> Component.literal("Current volume is %s%%".formatted(percentFormat.format(currentVolume * 100F))), false);
             return;
         }
-        if (volume == 100) {
+        if (volume == 100F) {
             // Will remove volume from json, to keep json file smaller
             mgr.setAudioVolume(id, null);
         }


### PR DESCRIPTION
also allow non integer volumes to be used as 1% is slightly louder then the previous 1%

this does not change how volumes are saved, so existing sounds stay the same volume, 2.0 is picked at random but it seems right